### PR TITLE
Remove build container package upgrades

### DIFF
--- a/build_dockerfile
+++ b/build_dockerfile
@@ -1,7 +1,6 @@
 FROM devkitpro/devkitppc:latest
 
 RUN ["apt", "update"]
-RUN ["apt", "upgrade", "-y"]
 RUN ["apt", "install", "clang", "-y"]
 RUN ["dkp-pacman", "-Syu", "--noconfirm"]
 RUN ["dkp-pacman", "-S", "ppc-libzip", "--noconfirm"]


### PR DESCRIPTION
Updating all packages in the container is not necessary and just adds on the total build time which is valuable